### PR TITLE
Sync day-night cycle with simulation calendar

### DIFF
--- a/src/core/time.js
+++ b/src/core/time.js
@@ -1,6 +1,7 @@
 // core/time.js
 export const REAL_LEVEL_MIN = 200;                 // 200 minutos por nivel
 export const REAL_LEVEL_SEC = REAL_LEVEL_MIN * 60; // 12000 s
+export const MINUTES_PER_SIM_DAY = 24 * 60;
 
 export const LEVELS = [
   { id: 1, name: 'Costa norte del Perú', start: '2023-01-01', days: 31+28+31+30 },       // 120
@@ -53,7 +54,13 @@ export function getSimDate(){ // Date “del calendario” actual
   return new Date(TimeState.simStartDate.getTime() + ms);
 }
 export function getSimDayNumber(){ // 1..levelDays
-  return Math.min(1 + Math.floor(TimeState.simMinutes / (24*60)), TimeState.levelDays);
+  return Math.min(1 + Math.floor(TimeState.simMinutes / MINUTES_PER_SIM_DAY), TimeState.levelDays);
+}
+
+export function getSimDayProgress01(){
+  if (!TimeState.levelDays) return 0;
+  const minutesToday = ((TimeState.simMinutes % MINUTES_PER_SIM_DAY) + MINUTES_PER_SIM_DAY) % MINUTES_PER_SIM_DAY;
+  return minutesToday / MINUTES_PER_SIM_DAY;
 }
 export function levelProgress01(){
   return Math.min(TimeState.elapsedRealSec / TimeState.levelRealBudgetSec, 1);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -8,7 +8,7 @@ import { tickCrops } from '../systems/cropSystem.js';
 import { tickPlagues } from '../systems/plagueSystem.js';
 import { tickAlerts } from '../systems/alertSystem.js';
 import { findFirstPlayer, spend } from '../core/state.js';
-import { startLevel, tickSim, TimeState } from '../core/time.js';
+import { startLevel, tickSim, getSimDayProgress01 } from '../core/time.js';
 import { T, MAP_PRESETS, makePlayableMatrix, makeWorldMatrix, buildBlockIndex, buildFromPreset } from '../map/mapBuilder.js';
 import { DECOR, addDecor } from '../map/decor.js';
 
@@ -219,8 +219,7 @@ export default class GameScene extends Phaser.Scene {
     this.keyA = null;
     this._cooldowns = { water: 0, plow: 0, harvest: 0, plant: 0 };
     this.decorEntries = [];      // ← entradas {sprite, shadow, def} de addDecor()
-    this.timeOfDay = 0.5;          // 0..1
-    this.dayLengthMs = 60000;   // 120 s por “día” (ajústalo)
+    this.timeOfDay = 0.5;          // 0..1 (se sincroniza con la simulación al iniciar)
   }
 
   create() {
@@ -228,6 +227,7 @@ export default class GameScene extends Phaser.Scene {
     cam.setBackgroundColor(0x859e70);
 
     startLevel(0);
+    this.timeOfDay = getSimDayProgress01();
     if (this.input?.setTopOnly) this.input.setTopOnly(true);
     Factory.createPlayer({ name: 'AgroPro', cartera: 200 });
     Factory.createTienda();
@@ -757,16 +757,20 @@ export default class GameScene extends Phaser.Scene {
       this.ambient.setSize(cam.worldView.width, cam.worldView.height);
     }
 
-    // 2) Día/tarde/noche + sombras
-    this.tickDayNight(delta);
+    // 2) Avanza la simulación temporal antes de derivar efectos visuales
+    State.clock += 1;
+    tickSim(delta);
 
-    // 3) Cooldowns
+    // 3) Día/tarde/noche + sombras basados en TimeState
+    this.tickDayNight();
+
+    // 4) Cooldowns
     const dec = delta;
     for (const k in this._cooldowns) {
       this._cooldowns[k] = Math.max(0, (this._cooldowns[k] || 0) - dec);
     }
 
-    // 4) Cámara (wasd/flechas)
+    // 5) Cámara (wasd/flechas)
     const cam = this.cameras.main;
     const dt = delta / 1000;
     const v = this.camSpeed / cam.zoom;
@@ -775,17 +779,15 @@ export default class GameScene extends Phaser.Scene {
     if (this.cursors?.up.isDown)    cam.scrollY -= v * dt;
     if (this.cursors?.down.isDown)  cam.scrollY += v * dt;
 
-    // 5) Atajos
+    // 6) Atajos
     if (Phaser.Input.Keyboard.JustDown(this.keyA)) this.plowSelected();
     if (Phaser.Input.Keyboard.JustDown(this.keyR)) this.waterSelected();
     if (Phaser.Input.Keyboard.JustDown(this.keyC)) this.harvestSelected();
 
-    // 6) Simulación
-    State.clock += 1;
-    tickSim(delta);
+    // 7) Simulación
     tickClimate(); tickCrops(); tickPlagues(); tickAlerts();
 
-    // 7) Secado periódico
+    // 8) Secado periódico
     if ((State.clock % 15) === 0) {
       for (const p of repoAll('parcelas')) {
         if (p.wetUntil && State.clock >= p.wetUntil) {
@@ -796,9 +798,12 @@ export default class GameScene extends Phaser.Scene {
     }
   }
 
-  tickDayNight(delta) {
-    // ===== Avanza el tiempo 0..1
-    this.timeOfDay = (this.timeOfDay + delta / this.dayLengthMs) % 1;
+  tickDayNight() {
+    // ===== Sincroniza con el reloj de la simulación (0..1)
+    const tSim = getSimDayProgress01();
+    if (!Number.isNaN(tSim)) {
+      this.timeOfDay = tSim;
+    }
 
     // ===== Fases (tu lógica)
     const t = this.timeOfDay;


### PR DESCRIPTION
## Summary
- add a shared constant and helper to expose the simulation day fraction
- advance the simulation clock before rendering and derive the day/night lighting from the shared time state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e310aefd8c83249037b47a45e26835