### PR TITLE
Expand localization across UI and gameplay

### DIFF
--- a/src/data/menuTranslations.json
+++ b/src/data/menuTranslations.json
@@ -1,0 +1,224 @@
+{
+    "es": {
+        "menu": {
+            "languageLabel": "Idioma",
+            "startButton": "INICIAR JUEGO",
+            "videoButton": "VIDEOTUTORIAL (Pr\u00f3x.)",
+            "profileTitle": "Crea tu Perfil de Agente",
+            "playerNamePlaceholder": "Tu Nombre",
+            "defaultPlayerName": "Agente",
+            "profileContinue": "Continuar",
+            "modeSelectTitle": "Selecciona tu Misi\u00f3n",
+            "modeAdventureTitle": "Modo Aventura",
+            "modeAdventureDescription": "Campa\u00f1a global por biomas y niveles.",
+            "modeLegacyTitle": "Modo Legado",
+            "modeLegacyDescription": "Sandbox infinito en una regi\u00f3n.",
+            "countries": {
+                "peru": "Per\u00fa",
+                "india": "India",
+                "brazil": "Brasil",
+                "ethiopia": "Etiop\u00eda",
+                "usa": "EE.UU."
+            }
+        },
+        "ui": {
+            "defaultPlayerName": "Agente",
+            "defaultLocation": "Pampa H\u00fameda, AR",
+            "dayLabel": "D\u00eda",
+            "dayDisplay": "{{label}}: {{day}}",
+            "clockFallbackLevel": "Nivel",
+            "clockDisplay": "{{level}} \u2014 {{dayLabel}} {{day}}/{{totalDays}} \u2014 {{date}}",
+            "fpsLabel": "FPS: {{value}}",
+            "moneyLabel": "\u20b2 {{value}}",
+            "inspectTitle": "\ud83d\udd2c Inspecci\u00f3n de Parcela",
+            "inspectPlaceholder": "Selecciona una parcela\u2026",
+            "inspect": {
+                "parcel": "Parcela: #{{id}}",
+                "soil": "Suelo: {{value}}",
+                "soilUnknown": "??",
+                "crop": "Cultivo: {{type}} ({{stage}} {{progress}}%)",
+                "cropNone": "Cultivo: -",
+                "water": "Agua: {{value}}",
+                "waterNone": "Agua: -"
+            },
+            "alertsTitle": "\u26a0\ufe0f Alertas del Sistema",
+            "alertsEmpty": "No hay alertas activas.",
+            "actionPanelTitle": "Decisiones",
+            "barLabels": {
+                "health": "SALUD (NDVI)",
+                "heat": "CALOR (Estr\u00e9s)",
+                "water": "HUMEDAD (SMAP RZSM)",
+                "humidity": "LLUVIA (GPM)",
+                "money": "DINERO ($)",
+                "energy": "ENERG\u00cdA (\u26a1)"
+            },
+            "actions": {
+                "plow": {
+                    "label": "\ud83d\ude9c Arar",
+                    "feedback": "\ud83d\ude9c Arado ejecutado"
+                },
+                "water": {
+                    "label": "\ud83d\udca7 Regar",
+                    "feedback": "\ud83d\udca7 Riego ejecutado"
+                },
+                "plant": {
+                    "label": "\ud83c\udf31 Sembrar",
+                    "feedback": "\ud83c\udf31 Siembra iniciada"
+                },
+                "harvest": {
+                    "label": "\ud83c\udf3e Cosechar",
+                    "feedback": "\ud83c\udf3e Cosecha intentada"
+                },
+                "upgrade": {
+                    "label": "\u2699\ufe0f Mejorar (Tech)",
+                    "feedback": "\u2699\ufe0f Abriendo Tech-Tree"
+                },
+                "scan": {
+                    "label": "\ud83d\udef0\ufe0f Escanear (Data)",
+                    "feedback": "\ud83d\udef0\ufe0f Extrayendo Data NASA..."
+                },
+                "sell": {
+                    "label": "\ud83d\udcb0 Vender Cosecha",
+                    "feedback": "\ud83d\udcb0 Mercado actualizado"
+                }
+            }
+        },
+        "game": {
+            "hudShortcuts": "ISO 256\u00d7128 \u2014 Arar (A) / Riega (R) / Cosecha (C) \u2014 Click bloque para seleccionar",
+            "toasts": {
+                "parcelAlreadyPlowed": "{{parcel}} ya est\u00e1 arada.",
+                "plowSuccess": "Araste {{parcel}}.",
+                "insufficientFunds": "Fondos insuficientes ({{amount}}).",
+                "noWater": "La parcela {{parcel}} no tiene AGUA.",
+                "waterSuccess": "Riego aplicado a {{parcel}}.",
+                "noCrop": "No hay cultivo en esta parcela.",
+                "cropNotReady": "{{crop}} no est\u00e1 listo. Progreso: {{progress}}%",
+                "unknownCrop": "Cultivo desconocido.",
+                "harvestSuccess": "Cosechado {{crop}}: +{{amount}}",
+                "selectParcelFirst": "Selecciona una parcela primero.",
+                "plowFirst": "Debes arar la tierra primero (A).",
+                "parcelAlreadyPlanted": "{{parcel}} ya tiene {{crop}}.",
+                "availableCrops": "Cultivos disponibles:\n{{list}}",
+                "cropMissing": "Cultivo {{crop}} no existe.",
+                "plantSuccess": "Sembraste {{crop}} en {{parcel}}.",
+                "techTree": "Tech Tree (WIP): Riego por goteo, sensores, energ\u00eda solar\u2026",
+                "selectParcelForScan": "Selecciona una parcela para escanear.",
+                "scanSummary": "\ud83d\udef0\ufe0f Scan NASA\n\u2022 SMAP (RZSM): {{smap}}%\n\u2022 NDVI (salud): {{ndvi}}%\n\u2022 Estr\u00e9s t\u00e9rmico: {{heat}}%",
+                "sellSuccess": "Venta realizada: {{count}} cosechas = +{{amount}}",
+                "noHarvestReady": "No hay cosechas listas.",
+                "genericCropName": "cultivo"
+            }
+        }
+    },
+    "en": {
+        "menu": {
+            "languageLabel": "Language",
+            "startButton": "START GAME",
+            "videoButton": "VIDEO TUTORIAL (Coming Soon)",
+            "profileTitle": "Create Your Agent Profile",
+            "playerNamePlaceholder": "Your Name",
+            "defaultPlayerName": "Agent",
+            "profileContinue": "Continue",
+            "modeSelectTitle": "Choose Your Mission",
+            "modeAdventureTitle": "Adventure Mode",
+            "modeAdventureDescription": "Global campaign across biomes and levels.",
+            "modeLegacyTitle": "Legacy Mode",
+            "modeLegacyDescription": "Endless sandbox in a single region.",
+            "countries": {
+                "peru": "Peru",
+                "india": "India",
+                "brazil": "Brazil",
+                "ethiopia": "Ethiopia",
+                "usa": "USA"
+            }
+        },
+        "ui": {
+            "defaultPlayerName": "Agent",
+            "defaultLocation": "Humid Pampas, AR",
+            "dayLabel": "Day",
+            "dayDisplay": "{{label}}: {{day}}",
+            "clockFallbackLevel": "Level",
+            "clockDisplay": "{{level}} \u2014 {{dayLabel}} {{day}}/{{totalDays}} \u2014 {{date}}",
+            "fpsLabel": "FPS: {{value}}",
+            "moneyLabel": "\u20b2 {{value}}",
+            "inspectTitle": "\ud83d\udd2c Plot Inspection",
+            "inspectPlaceholder": "Select a plot\u2026",
+            "inspect": {
+                "parcel": "Plot: #{{id}}",
+                "soil": "Soil: {{value}}",
+                "soilUnknown": "??",
+                "crop": "Crop: {{type}} ({{stage}} {{progress}}%)",
+                "cropNone": "Crop: -",
+                "water": "Water: {{value}}",
+                "waterNone": "Water: -"
+            },
+            "alertsTitle": "\u26a0\ufe0f System Alerts",
+            "alertsEmpty": "No active alerts.",
+            "actionPanelTitle": "Decisions",
+            "barLabels": {
+                "health": "HEALTH (NDVI)",
+                "heat": "HEAT (Stress)",
+                "water": "SOIL MOISTURE (SMAP RZSM)",
+                "humidity": "RAINFALL (GPM)",
+                "money": "MONEY ($)",
+                "energy": "ENERGY (\u26a1)"
+            },
+            "actions": {
+                "plow": {
+                    "label": "\ud83d\ude9c Plow",
+                    "feedback": "\ud83d\ude9c Plow complete"
+                },
+                "water": {
+                    "label": "\ud83d\udca7 Water",
+                    "feedback": "\ud83d\udca7 Irrigation applied"
+                },
+                "plant": {
+                    "label": "\ud83c\udf31 Plant",
+                    "feedback": "\ud83c\udf31 Planting started"
+                },
+                "harvest": {
+                    "label": "\ud83c\udf3e Harvest",
+                    "feedback": "\ud83c\udf3e Harvest attempt"
+                },
+                "upgrade": {
+                    "label": "\u2699\ufe0f Upgrade (Tech)",
+                    "feedback": "\u2699\ufe0f Opening Tech Tree"
+                },
+                "scan": {
+                    "label": "\ud83d\udef0\ufe0f Scan (Data)",
+                    "feedback": "\ud83d\udef0\ufe0f Pulling NASA Data..."
+                },
+                "sell": {
+                    "label": "\ud83d\udcb0 Sell Harvest",
+                    "feedback": "\ud83d\udcb0 Market updated"
+                }
+            }
+        },
+        "game": {
+            "hudShortcuts": "ISO 256\u00d7128 \u2014 Plow (A) / Water (R) / Harvest (C) \u2014 Click a block to select",
+            "toasts": {
+                "parcelAlreadyPlowed": "{{parcel}} is already plowed.",
+                "plowSuccess": "You plowed {{parcel}}.",
+                "insufficientFunds": "Insufficient funds ({{amount}}).",
+                "noWater": "Parcel {{parcel}} has no WATER.",
+                "waterSuccess": "Irrigation applied to {{parcel}}.",
+                "noCrop": "No crop on this parcel.",
+                "cropNotReady": "{{crop}} is not ready. Progress: {{progress}}%",
+                "unknownCrop": "Unknown crop.",
+                "harvestSuccess": "Harvested {{crop}}: +{{amount}}",
+                "selectParcelFirst": "Select a parcel first.",
+                "plowFirst": "You must plow the soil first (A).",
+                "parcelAlreadyPlanted": "{{parcel}} already has {{crop}}.",
+                "availableCrops": "Available crops:\n{{list}}",
+                "cropMissing": "Crop {{crop}} does not exist.",
+                "plantSuccess": "You planted {{crop}} on {{parcel}}.",
+                "techTree": "Tech Tree (WIP): Drip irrigation, sensors, solar energy\u2026",
+                "selectParcelForScan": "Select a parcel to scan.",
+                "scanSummary": "\ud83d\udef0\ufe0f NASA Scan\n\u2022 SMAP (RZSM): {{smap}}%\n\u2022 NDVI (health): {{ndvi}}%\n\u2022 Heat stress: {{heat}}%",
+                "sellSuccess": "Sale complete: {{count}} harvests = +{{amount}}",
+                "noHarvestReady": "No harvests ready.",
+                "genericCropName": "crop"
+            }
+        }
+    }
+}

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -1,44 +1,57 @@
 // src/scenes/MenuScene.js
 import Phaser from 'phaser';
 // import { Events, EVT } from '../core/events.js'; // opcional si vas a emitir payloads
+import { DEFAULT_LANGUAGE, getLanguage, setLanguage, translate as t } from '../utils/i18n.js';
 
 // ⚠️ SIN <style> ADENTRO y con UN ÚNICO root (lo metemos dentro de un <div> que creamos nosotros)
 const MENU_HTML_CONTENT = `
+  <div class="language-selector">
+    <label for="language-select" data-i18n="menu.languageLabel"></label>
+    <select id="language-select">
+      <option value="es">Español</option>
+      <option value="en">English</option>
+    </select>
+  </div>
+
   <!-- start -->
   <div id="start-screen" class="screen active low-poly-bg" style="align-items:center; justify-content:center; flex-direction:column;">
     <h1 style="font-size:5rem; font-weight:800; color:white; text-shadow: 2px 2px 8px rgba(0,0,0,.6); margin-bottom:1.5rem;">CULTIVARIUM</h1>
     <div style="display:flex; gap:1rem; flex-direction:column;">
-      <button id="btn-start" class="btn-primary">INICIAR JUEGO</button>
-      <button class="btn-secondary" disabled>VIDEOTUTORIAL (Próx.)</button>
+      <button id="btn-start" class="btn-primary" data-i18n="menu.startButton">INICIAR JUEGO</button>
+      <button id="btn-video" class="btn-secondary" data-i18n="menu.videoButton" disabled>VIDEOTUTORIAL (Próx.)</button>
     </div>
   </div>
 
   <!-- perfil -->
   <div id="profile-screen" class="screen low-poly-bg" style="align-items:center; justify-content:center;">
     <div class="glass-panel" style="padding:3rem; width:min(90vw,560px); text-align:center;">
-      <h2 style="font-size:2rem; font-weight:800; margin-bottom:1rem;">Crea tu Perfil de Agente</h2>
+      <h2 style="font-size:2rem; font-weight:800; margin-bottom:1rem;" data-i18n="menu.profileTitle">Crea tu Perfil de Agente</h2>
       <div style="display:flex; gap:1rem; flex-direction:column;">
-        <input id="player-name" type="text" placeholder="Tu Nombre" style="background:transparent; border-bottom:2px solid #ffffff88; color:white; font-size:1.2rem; padding:.5rem; text-align:center;">
+        <input id="player-name" type="text" placeholder="Tu Nombre" data-i18n-placeholder="menu.playerNamePlaceholder" style="background:transparent; border-bottom:2px solid #ffffff88; color:white; font-size:1.2rem; padding:.5rem; text-align:center;">
         <select id="player-country" style="background:transparent; border-bottom:2px solid #ffffff88; color:white; font-size:1.2rem; padding:.5rem; text-align:center;">
-          <option>Perú</option><option>India</option><option>Brasil</option><option>Etiopía</option><option>EE.UU.</option>
+          <option data-i18n-option="menu.countries.peru">Perú</option>
+          <option data-i18n-option="menu.countries.india">India</option>
+          <option data-i18n-option="menu.countries.brazil">Brasil</option>
+          <option data-i18n-option="menu.countries.ethiopia">Etiopía</option>
+          <option data-i18n-option="menu.countries.usa">EE.UU.</option>
         </select>
       </div>
-      <button id="btn-profile-next" class="btn-primary" style="margin-top:1.2rem;">Continuar</button>
+      <button id="btn-profile-next" class="btn-primary" style="margin-top:1.2rem;" data-i18n="menu.profileContinue">Continuar</button>
     </div>
   </div>
 
   <!-- modo -->
   <div id="mode-select-screen" class="screen low-poly-bg" style="align-items:center; justify-content:center;">
     <div class="glass-panel" style="padding:3rem; width:min(92vw,960px); text-align:center;">
-      <h2 style="font-size:2rem; font-weight:800; margin-bottom:1rem;">Selecciona tu Misión</h2>
+      <h2 style="font-size:2rem; font-weight:800; margin-bottom:1rem;" data-i18n="menu.modeSelectTitle">Selecciona tu Misión</h2>
       <div style="display:flex; gap:1rem; flex-wrap:wrap; justify-content:center;">
         <div id="card-adventure" style="flex:1 1 320px; border:2px solid #22d3ee; border-radius:1rem; padding:1rem; cursor:pointer;">
-          <h3 style="color:#22d3ee; font-weight:800;">Modo Aventura</h3>
-          <p>Campaña global por biomas y niveles.</p>
+          <h3 style="color:#22d3ee; font-weight:800;" data-i18n="menu.modeAdventureTitle">Modo Aventura</h3>
+          <p data-i18n="menu.modeAdventureDescription">Campaña global por biomas y niveles.</p>
         </div>
         <div id="card-legacy" style="flex:1 1 320px; border:2px solid #facc15; border-radius:1rem; padding:1rem; cursor:pointer;">
-          <h3 style="color:#facc15; font-weight:800;">Modo Legado</h3>
-          <p>Sandbox infinito en una región.</p>
+          <h3 style="color:#facc15; font-weight:800;" data-i18n="menu.modeLegacyTitle">Modo Legado</h3>
+          <p data-i18n="menu.modeLegacyDescription">Sandbox infinito en una región.</p>
         </div>
       </div>
     </div>
@@ -104,6 +117,44 @@ export default class MenuScene extends Phaser.Scene {
     const qa = (sel) => this.root.node.querySelectorAll(sel);
     const show = (id) => { qa('.screen').forEach(el=>el.classList.remove('active')); q(id)?.classList.add('active'); };
 
+    const applyLanguage = (lang) => {
+      const targetLang = setLanguage(lang);
+      this.currentLanguage = targetLang;
+
+      qa('[data-i18n]').forEach((el) => {
+        const key = el.getAttribute('data-i18n');
+        if (!key) return;
+        const value = t(key, {}, targetLang);
+        if (typeof value === 'string') {
+          el.textContent = value;
+        }
+      });
+
+      qa('[data-i18n-placeholder]').forEach((el) => {
+        const key = el.getAttribute('data-i18n-placeholder');
+        if (!key) return;
+        const value = t(key, {}, targetLang);
+        if (typeof value === 'string') {
+          el.setAttribute('placeholder', value);
+        }
+      });
+
+      qa('[data-i18n-option]').forEach((el) => {
+        const key = el.getAttribute('data-i18n-option');
+        if (!key) return;
+        const value = t(key, {}, targetLang);
+        if (typeof value === 'string') {
+          el.textContent = value;
+          el.value = value;
+        }
+      });
+
+      const languageSelect = q('language-select');
+      if (languageSelect) {
+        languageSelect.value = targetLang;
+      }
+    };
+
     // estilos utilitarios usados por el HTML (antes en <style>)
     const styleTag = document.createElement('style');
     styleTag.textContent = `
@@ -111,6 +162,10 @@ export default class MenuScene extends Phaser.Scene {
       .screen.active{display:flex}
       .low-poly-bg{background:#8DA86C}
       .glass-panel{background:rgba(15,23,42,.6);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.1);border-radius:1.5rem;color:#F4F0E1}
+      .language-selector{position:absolute;top:1.5rem;right:1.5rem;display:flex;align-items:center;gap:.5rem;padding:.6rem 1rem;background:rgba(15,23,42,.6);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.2);border-radius:9999px;color:#F4F0E1;font-weight:600}
+      .language-selector label{font-weight:700;letter-spacing:.02em}
+      .language-selector select{background:transparent;border:none;color:inherit;font-weight:600;padding:.2rem .6rem;border-radius:.5rem;cursor:pointer}
+      .language-selector select:focus{outline:2px solid rgba(230,214,166,.7);outline-offset:2px}
       .btn-primary{background:#E6D6A6;color:#5B3A29;padding:.8rem 2rem;border-radius:9999px;font-weight:700;cursor:pointer}
       .btn-secondary{background:transparent;border:2px solid #E6D6A6;color:#E6D6A6;padding:.8rem 2rem;border-radius:9999px;font-weight:700}
       .level-node{position:absolute;width:60px;height:60px;background:#C85E4B;border:3px solid #F4F0E1;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:1.4rem;font-weight:700;cursor:pointer;box-shadow:0 5px 15px rgba(0,0,0,.4)}
@@ -119,11 +174,23 @@ export default class MenuScene extends Phaser.Scene {
     `;
     this.root.node.prepend(styleTag);
 
+    const languageSelect = q('language-select');
+    languageSelect?.addEventListener('change', (event) => {
+      applyLanguage(event.target.value);
+    });
+
+    applyLanguage(getLanguage() || DEFAULT_LANGUAGE);
+
     q('btn-start')?.addEventListener('click', () => show('profile-screen'));
     q('btn-profile-next')?.addEventListener('click', () => {
       const name = q('player-name')?.value?.trim();
       const country = q('player-country')?.value;
-      this.profile = { name: name || 'Jugador', country: country || 'Perú' };
+      const defaultName = t('menu.defaultPlayerName');
+      const defaultCountry = t('menu.countries.peru');
+      this.profile = {
+        name: name || defaultName || 'Agente',
+        country: country || defaultCountry || 'Perú',
+      };
       show('mode-select-screen');
     });
     q('card-adventure')?.addEventListener('click', () => show('adventure-map-screen'));
@@ -138,7 +205,8 @@ export default class MenuScene extends Phaser.Scene {
   }
 
   startGame(payload){
-    window.__CV_START__ = payload;
+    const language = this.currentLanguage || getLanguage() || DEFAULT_LANGUAGE;
+    window.__CV_START__ = { ...payload, language };
 
     this.scale.off('resize', this._onResize, this);
     this.root?.destroy();

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -1,6 +1,15 @@
 import Phaser from 'phaser';
 import { State, repoAll, findFirstPlayer, repoGet } from '../core/state.js';
 import { TimeState, getSimDate, getSimDayNumber, LEVELS } from '../core/time.js';
+import { getLanguage, setLanguage, translate as t } from '../utils/i18n.js';
+
+const formatDate = (date) => {
+  if (!(date instanceof Date)) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
 
 export default class UIScene extends Phaser.Scene {
   constructor() {
@@ -20,6 +29,8 @@ export default class UIScene extends Phaser.Scene {
   }
 
   create() {
+    setLanguage(window.__CV_START__?.language || getLanguage());
+
     const screenW = this.scale.width;
     const screenH = this.scale.height;
 
@@ -63,9 +74,18 @@ export default class UIScene extends Phaser.Scene {
     this.populateActionPanel(this.actionPanel, colors);
 
     // ===== HUD Principal (Elementos Fijos y Vitales) =====
-    this.clockText = this.add.text(screenW / 2, 10, 'Nivel — Día 1', { fontSize: '14px', color: colors.textPrimary, fontStyle: 'bold', backgroundColor: 'rgba(0,0,0,0.5)', padding: { x: 10, y: 5 } }).setOrigin(0.5, 0).setDepth(100);
-    this.fpsText = this.add.text(screenW - 10, 10, 'FPS: 60', { fontSize: '10px', color: colors.dataAccent, backgroundColor: 'rgba(0,0,0,0.3)' }).setOrigin(1, 0).setDepth(100);
-    this.moneyText = this.add.text(screenW / 2, 35, '₲ 0', { fontSize: '24px', color: colors.bar.money, fontStyle: 'bold', backgroundColor: 'rgba(0,0,0,0.5)', padding: { x: 12, y: 5 } }).setOrigin(0.5, 0).setDepth(100);
+    const levelName = (LEVELS?.[TimeState.levelIdx]?.name) || t('ui.clockFallbackLevel');
+    const dayLabel = t('ui.dayLabel');
+    const initialClock = t('ui.clockDisplay', {
+      level: levelName,
+      dayLabel,
+      day: getSimDayNumber(),
+      totalDays: TimeState.levelDays ?? 0,
+      date: formatDate(getSimDate()),
+    });
+    this.clockText = this.add.text(screenW / 2, 10, initialClock, { fontSize: '14px', color: colors.textPrimary, fontStyle: 'bold', backgroundColor: 'rgba(0,0,0,0.5)', padding: { x: 10, y: 5 } }).setOrigin(0.5, 0).setDepth(100);
+    this.fpsText = this.add.text(screenW - 10, 10, t('ui.fpsLabel', { value: 60 }), { fontSize: '10px', color: colors.dataAccent, backgroundColor: 'rgba(0,0,0,0.3)' }).setOrigin(1, 0).setDepth(100);
+    this.moneyText = this.add.text(screenW / 2, 35, t('ui.moneyLabel', { value: 0 }), { fontSize: '24px', color: colors.bar.money, fontStyle: 'bold', backgroundColor: 'rgba(0,0,0,0.5)', padding: { x: 12, y: 5 } }).setOrigin(0.5, 0).setDepth(100);
 
     // Inicializa la animación de alerta crítica (Estrés por Calor)
     // Se inicializa el tween en el fondo de la barra de calor, el cual ya está creado en populateStatusPanel
@@ -80,11 +100,36 @@ export default class UIScene extends Phaser.Scene {
 
     // ===== Listeners de juego (Toasts y Inspección) =====
     this.game.events.on('inspect:parcela', (data) => {
+      const soilValueRaw = data.saludSuelo !== undefined && data.saludSuelo !== null
+        ? Number(data.saludSuelo) * 100
+        : null;
+      const soilValue = Number.isFinite(soilValueRaw)
+        ? `${soilValueRaw.toFixed(0)}%`
+        : t('ui.inspect.soilUnknown');
+
+      const cropProgressRaw = data.cultivo?.progreso !== undefined && data.cultivo?.progreso !== null
+        ? Number(data.cultivo.progreso) * 100
+        : null;
+      const cropLine = data.cultivo
+        ? t('ui.inspect.crop', {
+            type: data.cultivo.tipo,
+            stage: data.cultivo.etapa,
+            progress: cropProgressRaw !== null && Number.isFinite(cropProgressRaw) ? cropProgressRaw.toFixed(0) : '0',
+          })
+        : t('ui.inspect.cropNone');
+
+      const waterValueRaw = data.agua?.nivel !== undefined && data.agua?.nivel !== null
+        ? Number(data.agua.nivel) * 100
+        : null;
+      const waterLine = data.agua
+        ? t('ui.inspect.water', { value: `${Number.isFinite(waterValueRaw) ? waterValueRaw.toFixed(0) : '0'}%` })
+        : t('ui.inspect.waterNone');
+
       const lines = [
-        `Parcela: #${data.id}`,
-        `Suelo: ${data.saludSuelo ? (data.saludSuelo * 100).toFixed(0) + '%' : '??'}`,
-        data.cultivo ? `Cultivo: ${data.cultivo.tipo} (${data.cultivo.etapa} ${(data.cultivo.progreso * 100).toFixed(0)}%)` : 'Cultivo: -',
-        data.agua ? `Agua: ${(data.agua.nivel * 100).toFixed(0)}%` : 'Agua: -'
+        t('ui.inspect.parcel', { id: data.id ?? '--' }),
+        t('ui.inspect.soil', { value: soilValue }),
+        cropLine,
+        waterLine,
       ];
       this.inspectText.setText(lines.join('\n'));
     });
@@ -136,15 +181,15 @@ export default class UIScene extends Phaser.Scene {
     let y = 20;
 
     // Nombre / Ubicación
-    this.playerNameText = this.add.text(W / 2, y, 'Agente', { fontSize: '24px', color: colors.textPrimary, fontStyle: 'bold' }).setOrigin(0.5, 0); 
-    this.locationText   = this.add.text(W / 2, y += 30, 'Pampa Húmeda, AR', { fontSize: '16px', color: colors.textSecondary }).setOrigin(0.5, 0);
+    this.playerNameText = this.add.text(W / 2, y, t('ui.defaultPlayerName'), { fontSize: '24px', color: colors.textPrimary, fontStyle: 'bold' }).setOrigin(0.5, 0);
+    this.locationText   = this.add.text(W / 2, y += 30, t('ui.defaultLocation'), { fontSize: '16px', color: colors.textSecondary }).setOrigin(0.5, 0);
 
     // Día destacado (Aplica colores Data Accent)
-    this.dayText = this.add.text(W / 2, y += 30, 'Día: 1', {
+    this.dayText = this.add.text(W / 2, y += 30, t('ui.dayDisplay', { label: t('ui.dayLabel'), day: 1 }), {
       fontSize: '18px',
-      color: Phaser.Display.Color.IntegerToColor(colors.dataAccent).rgba, 
+      color: Phaser.Display.Color.IntegerToColor(colors.dataAccent).rgba,
       fontStyle: '600',
-      backgroundColor: Phaser.Display.Color.IntegerToColor(colors.dataPanelBg).rgba, 
+      backgroundColor: Phaser.Display.Color.IntegerToColor(colors.dataPanelBg).rgba,
       padding: { x: 12, y: 6 },
       align: 'center',
     }).setOrigin(0.5, 0);
@@ -153,12 +198,12 @@ export default class UIScene extends Phaser.Scene {
 
     // Barras
     this.bars = {
-      hp:       this.createHudBar('SALUD (NDVI)', y, colors.bar.hp, W, colors),
-      heat:     this.createHudBar('CALOR (Estrés)', y += 66, colors.bar.heat, W, colors),
-      water:    this.createHudBar('HUMEDAD (SMAP RZSM)', y += 66, colors.bar.water, W, colors),
-      humidity: this.createHudBar('LLUVIA (GPM)', y += 66, colors.bar.humidity, W, colors),
-      money:    this.createHudBar('DINERO ($)', y += 66, colors.bar.money, W, colors),
-      energy:   this.createHudBar('ENERGÍA (⚡)', y += 66, colors.bar.energy, W, colors),
+      hp:       this.createHudBar(t('ui.barLabels.health'), y, colors.bar.hp, W, colors),
+      heat:     this.createHudBar(t('ui.barLabels.heat'), y += 66, colors.bar.heat, W, colors),
+      water:    this.createHudBar(t('ui.barLabels.water'), y += 66, colors.bar.water, W, colors),
+      humidity: this.createHudBar(t('ui.barLabels.humidity'), y += 66, colors.bar.humidity, W, colors),
+      money:    this.createHudBar(t('ui.barLabels.money'), y += 66, colors.bar.money, W, colors),
+      energy:   this.createHudBar(t('ui.barLabels.energy'), y += 66, colors.bar.energy, W, colors),
     };
     Object.values(this.bars).forEach(bar => container.add(bar.elements));
 
@@ -167,8 +212,8 @@ export default class UIScene extends Phaser.Scene {
     container.add(sep1);
     y += 12;
 
-    this.inspectTitle = this.add.text(24, y, '🔬 Inspección de Parcela', { fontSize: '18px', color: colors.dataAccent, fontStyle: 'bold' });
-    this.inspectText  = this.add.text(24, y + 24, 'Selecciona una parcela…', { fontSize: '12px', color: colors.textSecondary, wordWrap: { width: W - 48 } });
+    this.inspectTitle = this.add.text(24, y, t('ui.inspectTitle'), { fontSize: '18px', color: colors.dataAccent, fontStyle: 'bold' });
+    this.inspectText  = this.add.text(24, y + 24, t('ui.inspectPlaceholder'), { fontSize: '12px', color: colors.textSecondary, wordWrap: { width: W - 48 } });
 
     container.add([this.playerNameText, this.locationText, this.dayText, this.inspectTitle, this.inspectText]);
     container.bringToTop(this.dayText);
@@ -177,8 +222,8 @@ export default class UIScene extends Phaser.Scene {
     container.add(sep2);
     y += 12;
 
-    this.alertsTitle = this.add.text(24, y, '⚠️ Alertas del Sistema', { fontSize: '18px', color: colors.bar.heat, fontStyle: 'bold' });
-    this.alertsText  = this.add.text(24, y + 24, 'No hay alertas activas.', { fontSize: '12px', color: colors.textPrimary, wordWrap: { width: W - 48 } });
+    this.alertsTitle = this.add.text(24, y, t('ui.alertsTitle'), { fontSize: '18px', color: colors.bar.heat, fontStyle: 'bold' });
+    this.alertsText  = this.add.text(24, y + 24, t('ui.alertsEmpty'), { fontSize: '12px', color: colors.textPrimary, wordWrap: { width: W - 48 } });
     container.add([this.alertsTitle, this.alertsText]);
   }
 
@@ -188,7 +233,7 @@ populateActionPanel(panel, colors) {
   const W = panel.width;
   let y = 20;
 
-  const title = this.add.text(W / 2, y, 'Decisiones', {
+  const title = this.add.text(W / 2, y, t('ui.actionPanelTitle'), {
     fontSize: '24px',
     color: colors.textPrimary,
     fontStyle: 'bold'
@@ -240,10 +285,10 @@ populateActionPanel(panel, colors) {
   };
 
   // --- BOTONES CLAVE (DECISIONES AGRÍCOLAS) ---
-  runAction('🚜 Arar',          'ARAR',         '🚜 Arado ejecutado',          colors.feedback.success, 'plowSelected');
-  runAction('💧 Regar',         'REGAR',        '💧 Riego ejecutado',          colors.feedback.success, 'waterSelected');
-  runAction('🌱 Sembrar',       'SEMBRAR',      '🌱 Siembra iniciada',         colors.feedback.success, 'plantSelected');
-  runAction('🌾 Cosechar',      'COSECHAR',     '🌾 Cosecha intentada',        0xfbbf24,               'harvestSelected');
+  runAction(t('ui.actions.plow.label'),     'ARAR',         t('ui.actions.plow.feedback'),     colors.feedback.success, 'plowSelected');
+  runAction(t('ui.actions.water.label'),    'REGAR',        t('ui.actions.water.feedback'),    colors.feedback.success, 'waterSelected');
+  runAction(t('ui.actions.plant.label'),    'SEMBRAR',      t('ui.actions.plant.feedback'),    colors.feedback.success, 'plantSelected');
+  runAction(t('ui.actions.harvest.label'),  'COSECHAR',     t('ui.actions.harvest.feedback'),  0xfbbf24,               'harvestSelected');
 
   // Separador
   const sep = this.add.graphics().fillStyle(colors.panelBorder, 0.5).fillRect(16, y += 40, W - 32, 2);
@@ -251,9 +296,9 @@ populateActionPanel(panel, colors) {
   y += 12;
 
   // --- AVANZADOS / TECNOLOGÍA & DATOS ---
-  runAction('⚙️ Mejorar (Tech)',   'UPGRADE_TECH', '⚙️ Abriendo Tech-Tree',      colors.dataAccent, null, 600);
-  runAction('🛰️ Escanear (Data)',  'SCAN_REGION',  '🛰️ Extrayendo Data NASA...', colors.dataAccent, null, 600);
-  runAction('💰 Vender Cosecha',    'SELL_HARVEST', '💰 Mercado actualizado',     colors.bar.money,  null, 600);
+  runAction(t('ui.actions.upgrade.label'), 'UPGRADE_TECH', t('ui.actions.upgrade.feedback'), colors.dataAccent, null, 600);
+  runAction(t('ui.actions.scan.label'),    'SCAN_REGION',  t('ui.actions.scan.feedback'),    colors.dataAccent, null, 600);
+  runAction(t('ui.actions.sell.label'),    'SELL_HARVEST', t('ui.actions.sell.feedback'),    colors.bar.money,  null, 600);
 }
     
   // ---------- Feedback flotante ----------
@@ -401,7 +446,8 @@ populateActionPanel(panel, colors) {
 
     // --- 2. Actualización de HUD Fijo y Efecto de Pulso en Día ---
     if (this.dayText) {
-        const currentDayText = `Día: ${dayN}`;
+        const dayLabel = t('ui.dayLabel');
+        const currentDayText = t('ui.dayDisplay', { label: dayLabel, day: dayN });
         if (this.dayText.text !== currentDayText) {
              // CINEMÁTICA: Pulso al cambiar el día
              this.tweens.add({
@@ -415,16 +461,22 @@ populateActionPanel(panel, colors) {
         }
         this.dayText.setText(currentDayText);
     }
-    
+
     // Actualización de HUD fijo
     if (this.clockText) {
+        const dayLabel = t('ui.dayLabel');
         this.clockText.setText(
-            `${L.name} — Día ${dayN}/${TimeState.levelDays} — ` +
-            `${getSimDate().getFullYear()}-${String(getSimDate().getMonth()+1).padStart(2,'0')}-${String(getSimDate().getDate()).padStart(2,'0')}`
+            t('ui.clockDisplay', {
+              level: L.name || t('ui.clockFallbackLevel'),
+              dayLabel,
+              day: dayN,
+              totalDays: TimeState.levelDays ?? 0,
+              date: formatDate(getSimDate()),
+            })
         );
     }
-    if (this.fpsText) this.fpsText.setText('FPS: ' + Math.floor(this.game.loop.actualFps || 0));
-    if (this.moneyText) this.moneyText.setText(`₲ ${player ? player.cartera.toFixed(0) : 0}`);
+    if (this.fpsText) this.fpsText.setText(t('ui.fpsLabel', { value: Math.floor(this.game.loop.actualFps || 0) }));
+    if (this.moneyText) this.moneyText.setText(t('ui.moneyLabel', { value: player ? player.cartera.toFixed(0) : 0 }));
     if (player && window.__CV_START__?.profile?.name && this.playerNameText) {
       this.playerNameText.setText(window.__CV_START__.profile.name);
     }
@@ -484,7 +536,7 @@ populateActionPanel(panel, colors) {
 
     // --- 5. Alertas (últimas 5) ---
     const alerts = repoAll('alertas').filter(a => a.visible !== false).slice(-5);
-    const atext = alerts.length ? alerts.map(a => `• ${a.mensaje}`).join('\n') : 'No hay alertas activas.';
+    const atext = alerts.length ? alerts.map(a => `• ${a.mensaje}`).join('\n') : t('ui.alertsEmpty');
     this.alertsText.setText(atext);
   }
 }

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -1,0 +1,70 @@
+import dictionaries from '../data/menuTranslations.json';
+
+export const DEFAULT_LANGUAGE = 'es';
+let currentLanguage = DEFAULT_LANGUAGE;
+
+function resolveKey(dict, key) {
+  if (!dict || !key) return undefined;
+  return key.split('.').reduce((acc, part) => {
+    if (acc && Object.prototype.hasOwnProperty.call(acc, part)) {
+      return acc[part];
+    }
+    return undefined;
+  }, dict);
+}
+
+function format(template, replacements = {}) {
+  if (typeof template !== 'string') return template;
+  return Object.entries(replacements).reduce(
+    (acc, [placeholder, value]) => acc.replaceAll(`{{${placeholder}}}`, String(value)),
+    template
+  );
+}
+
+export function setLanguage(lang) {
+  const nextLang = dictionaries[lang] ? lang : DEFAULT_LANGUAGE;
+  currentLanguage = nextLang;
+  if (typeof window !== 'undefined') {
+    window.__CV_LANG__ = nextLang;
+  }
+  return currentLanguage;
+}
+
+export function getLanguage() {
+  if (typeof window !== 'undefined' && window.__CV_LANG__) {
+    currentLanguage = window.__CV_LANG__;
+  }
+  return currentLanguage;
+}
+
+export function translate(key, replacements = {}, langOverride) {
+  const lang = langOverride || getLanguage();
+  const primaryDict = dictionaries[lang] || dictionaries[DEFAULT_LANGUAGE] || {};
+  let template = resolveKey(primaryDict, key);
+  if (template === undefined) {
+    const fallbackDict = dictionaries[DEFAULT_LANGUAGE] || {};
+    template = resolveKey(fallbackDict, key);
+  }
+  if (template === undefined) return key;
+  if (typeof template === 'string') {
+    return format(template, replacements);
+  }
+  return template;
+}
+
+export function getDictionary(lang = getLanguage()) {
+  return dictionaries[lang] || dictionaries[DEFAULT_LANGUAGE] || {};
+}
+
+export function getAvailableLanguages() {
+  return Object.keys(dictionaries);
+}
+
+export default {
+  DEFAULT_LANGUAGE,
+  getAvailableLanguages,
+  getDictionary,
+  getLanguage,
+  setLanguage,
+  translate,
+};


### PR DESCRIPTION
## Summary
- restructure the translations JSON to cover menu, HUD, and gameplay toasts in Spanish and English
- add a shared i18n helper and update the menu to drive the selected language into the game payload
- localize UIScene and GameScene HUD copy, inspection text, and toast messaging using the translation keys

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e327ce66c48324865e7781a5c83639