### PR TITLE
Integrate climate data with GameScene actions

### DIFF
--- a/src/core/factory.js
+++ b/src/core/factory.js
@@ -14,6 +14,8 @@ export const Factory = {
       name: overrides.name || 'Player 1',
       cartera: 1000,          // dinero disponible para la Tienda
       reputacion: 0,          // métrica social (misiones/eventos)
+      energiaMax: overrides.energiaMax ?? 100,
+      energiaActual: overrides.energiaActual ?? (overrides.energiaMax ?? 100),
       ...overrides
     };
     repoSet('jugadores', e);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -236,6 +236,12 @@ export default class GameScene extends Phaser.Scene {
 
     startLevel(0);
     this.timeOfDay = getSimDayProgress01();
+
+    const initialDay = getSimDayNumber();
+    _lastDay = initialDay - 1;
+    const initialIdx = Math.max(0, initialDay - 1);
+    tickClimate({ regionCode: State.region?.codigo, dayIndex: initialIdx })
+      .catch(err => console.error('climate:init', err));
     if (this.input?.setTopOnly) this.input.setTopOnly(true);
     Factory.createPlayer({ name: 'AgroPro', cartera: 200 });
     Factory.createTienda();
@@ -544,6 +550,8 @@ export default class GameScene extends Phaser.Scene {
     if (!parcela) return;
 
     this.selectedParcelaId = parcela.id;
+    const player = findFirstPlayer();
+    if (player) player.parcelaSeleccionadaId = parcela.id;
 
     const p = repoGet('parcelas', parcela.id);
     const c = p?.cultivoId ? repoGet('cultivos', p.cultivoId) : null;
@@ -776,8 +784,9 @@ export default class GameScene extends Phaser.Scene {
     const dayN = getSimDayNumber();
     if (dayN !== _lastDay) {
       _lastDay = dayN;
-      // Alinea el clima al día simulado
-      tickClimate({ regionCode: State.region?.codigo, dayIndex: dayN });
+      const dayIndex = Math.max(0, dayN - 1);
+      tickClimate({ regionCode: State.region?.codigo, dayIndex })
+        .catch(err => console.error('climate:tick', err));
     }
     tickCrops(); tickPlagues(); tickAlerts();
 

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -46,12 +46,13 @@ export default class UIScene extends Phaser.Scene {
       
       // Barras
       bar: {
-        hp: 0x00FFD1, // NDVI (Turquesa NASA)
-        heat: 0xf87171, // Rojo (Estrés por Calor)
+        hp: 0x00FFD1,    // NDVI (Turquesa NASA)
+        heat: 0xf87171,  // Rojo (Estrés por Calor)
         water: 0x60a5fa, // Azul (SMAP)
-        humidity: 0xfbbf24, // Amarillo (GPM/Lluvia)
-        money: 0xf59e0b, 
-        energy: 0xc084fc 
+        humidity: 0x2dd4bf, // Cian suave (Humedad relativa)
+        rain: 0xfbbf24,  // Amarillo (GPM/Lluvia)
+        money: 0xf59e0b,
+        energy: 0xc084fc
       },
     };
     this.colors = colors;
@@ -163,12 +164,13 @@ export default class UIScene extends Phaser.Scene {
 
     // Barras
     this.bars = {
-      hp:       this.createHudBar('SALUD (NDVI)', y, colors.bar.hp, W, colors),
-      heat:     this.createHudBar('CALOR (Estrés)', y += 66, colors.bar.heat, W, colors),
-      water:    this.createHudBar('HUMEDAD (SMAP RZSM)', y += 66, colors.bar.water, W, colors),
-      humidity: this.createHudBar('LLUVIA (GPM)', y += 66, colors.bar.humidity, W, colors),
-      money:    this.createHudBar('DINERO ($)', y += 66, colors.bar.money, W, colors),
-      energy:   this.createHudBar('ENERGÍA (⚡)', y += 66, colors.bar.energy, W, colors),
+      hp:        this.createHudBar('SALUD (NDVI)', y, colors.bar.hp, W, colors),
+      heat:      this.createHudBar('CALOR (Estrés)', y += 66, colors.bar.heat, W, colors),
+      water:     this.createHudBar('HUMEDAD (SMAP RZSM)', y += 66, colors.bar.water, W, colors),
+      humidity:  this.createHudBar('HUMEDAD (Relativa)', y += 66, colors.bar.humidity, W, colors),
+      rain:      this.createHudBar('LLUVIA (GPM)', y += 66, colors.bar.rain, W, colors),
+      money:     this.createHudBar('DINERO ($)', y += 66, colors.bar.money, W, colors),
+      energy:    this.createHudBar('ENERGÍA (⚡)', y += 66, colors.bar.energy, W, colors),
     };
     Object.values(this.bars).forEach(bar => container.add(bar.elements));
 
@@ -404,11 +406,12 @@ populateActionPanel(panel, colors) {
          const time = this.time.now;
          const mock = {
             hp: 0.75 + Math.sin(time / 1000) * 0.25,
-            heat: 0.40 + Math.cos(time / 800)  * 0.30,
+            heat: 0.40 + Math.cos(time / 800)  * 0.30,
             water: 0.50 + Math.sin(time / 1200) * 0.40,
             humidity: 0.60 + Math.cos(time / 1500) * 0.10,
+            rain: 0.50 + Math.sin(time / 900) * 0.25,
             money: 0.85 + Math.sin(time / 2000) * 0.05,
-            energy: 0.90 + Math.cos(time / 500)  * 0.10
+            energy: 0.90 + Math.cos(time / 500)  * 0.10
          };
          Object.keys(this.bars).forEach(k => this.bars[k].update(Phaser.Math.Clamp(mock[k], 0, 1)));
          hasEnergy = mock.energy > 0.1;
@@ -426,7 +429,10 @@ populateActionPanel(panel, colors) {
         heatValue = State.clima.estresTermico01;
         this.bars.heat.update(heatValue);
       }
-      this.bars.humidity.update(State?.clima?.lluviaGPM ?? 0); 
+
+      const clima = State?.clima || {};
+      if (this.bars.humidity) this.bars.humidity.update(clima.humedad01 ?? clima.humedadRelativa01 ?? 0);
+      if (this.bars.rain) this.bars.rain.update(clima.lluviaGPM ?? clima.precipitation01 ?? 0);
       
       if (p) {
         const eMax = p.energiaMax || 1;


### PR DESCRIPTION
## Summary
- align GameScene climate updates with the simulated day cycle and expose the selected parcel to the UI
- ensure newly created players have usable energy so action buttons remain interactive
- surface climate humidity and rainfall data in the HUD with dedicated bars

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e347052214832499149190d402d0f3