### PR TITLE
Implement crop growth mechanics and visuals

### DIFF
--- a/src/core/factory.js
+++ b/src/core/factory.js
@@ -76,13 +76,15 @@ export const Factory = {
     const e = {
       id: newId('cultivo'),
       tipo: overrides.tipo || 'MAIZ',
-      etapa: 'SIEMBRA',        // SIEMBRA->CRECIMIENTO->COSECHA
-      progreso: 0,             // 0..1
-      consumoAgua: 0.5,        // por tick (escala relativa)
-      sensibilidadClima: {     // multiplicadores por tipo de clima
+      etapa: overrides.etapa || 'SEMILLA',
+      progreso: overrides.progreso ?? 0,
+      consumoAgua: overrides.consumoAgua ?? 1.0,
+      resistenciaPlagas: overrides.resistenciaPlagas ?? 0,
+      saludActual: overrides.saludActual ?? 1.0,
+      sensibilidadClima: overrides.sensibilidadClima || {
         FRIO: 0.8, CALOR: 1.2, SEQUIA: 0.5, LLUVIA: 1.1
       },
-      plagas: [],              // ids de plagas presentes
+      plagas: overrides.plagas || [],
       ...overrides
     };
     repoSet('cultivos', e);

--- a/src/systems/cropSystem.js
+++ b/src/systems/cropSystem.js
@@ -1,30 +1,163 @@
 /**
  * Sistema de Cultivos
- * - Consume agua en base a consumoAgua y avanza progreso si hay recursos.
- * - Aplica penalizadores por clima/plagas (a integrar con Climate/Plague).
+ * - Gestiona crecimiento por etapas y consumo de agua.
+ * - Ajusta progreso según salud del suelo y salud del cultivo.
+ * - Emite actualizaciones visuales cuando cambia la etapa.
  */
 import { State, repoAll, repoGet } from '../core/state.js';
 
+// Configuración base de cultivos disponibles.
+export const CROP_CONFIG = {
+  MAIZ: {
+    nombre: 'Maíz',
+    diasCrecimiento: 30,
+    consumoAgua: 1.0,
+    precioVenta: 50,
+    costoSemilla: 15,
+    resistenciaPlagas: 0.1,
+    etapas: ['SEMILLA', 'BROTE', 'CRECIMIENTO', 'MADURO', 'COSECHA']
+  },
+  TRIGO: {
+    nombre: 'Trigo',
+    diasCrecimiento: 20,
+    consumoAgua: 0.8,
+    precioVenta: 35,
+    costoSemilla: 10,
+    resistenciaPlagas: 0.2,
+    etapas: ['SEMILLA', 'BROTE', 'CRECIMIENTO', 'MADURO', 'COSECHA']
+  },
+  PAPA: {
+    nombre: 'Papa',
+    diasCrecimiento: 25,
+    consumoAgua: 1.2,
+    precioVenta: 40,
+    costoSemilla: 12,
+    resistenciaPlagas: 0.15,
+    etapas: ['SEMILLA', 'BROTE', 'CRECIMIENTO', 'MADURO', 'COSECHA']
+  },
+  TOMATE: {
+    nombre: 'Tomate',
+    diasCrecimiento: 35,
+    consumoAgua: 1.3,
+    precioVenta: 60,
+    costoSemilla: 18,
+    resistenciaPlagas: 0.05,
+    etapas: ['SEMILLA', 'BROTE', 'CRECIMIENTO', 'MADURO', 'COSECHA']
+  }
+};
+
+const BASE_GROWTH_RATE = 0.002;
+const HEALTH_RECOVERY_RATE = 0.0003;
+const HEALTH_DECAY_RATE = 0.0005;
+const WATER_THRESHOLD_GROW = 0.2;
+const WATER_THRESHOLD_DECAY = 0.15;
+
+function notifyCropStageChange(cultivo) {
+  if (typeof window === 'undefined') return;
+  const phaserGame = window.__PHASER_GAME__ || window.game;
+  const scene = phaserGame?.scene?.keys?.Game;
+  if (scene?.updateCultivoSprite) {
+    scene.updateCultivoSprite(cultivo);
+  }
+}
+
 export function tickCrops() {
   const parcelas = repoAll('parcelas');
+
   for (const p of parcelas) {
     if (!p.cultivoId) continue;
-    const c = repoGet('cultivos', p.cultivoId);
-    if (!c) continue;
+    const cultivo = repoGet('cultivos', p.cultivoId);
+    if (!cultivo) continue;
 
-    // consumo de agua: busca un recurso AGUA en la parcela
-    const recAguaId = p.recursos.find(rid => State.repos.recursos.get(rid)?.tipo === 'AGUA');
-    if (recAguaId) {
-      const rec = State.repos.recursos.get(recAguaId);
-      rec.nivel = Math.max(0, rec.nivel - 0.002 * c.consumoAgua); // consumo simplificado
-      if (rec.nivel > 0.2) {
-        c.progreso = Math.min(1, c.progreso + 0.002); // crece si hay agua
+    if (typeof cultivo.saludActual !== 'number') cultivo.saludActual = 1;
+    cultivo.saludActual = Math.min(Math.max(cultivo.saludActual, 0), 1);
+
+    if (cultivo.saludActual <= 0) {
+      if (cultivo.etapa !== 'MUERTO') {
+        cultivo.etapa = 'MUERTO';
+        notifyCropStageChange(cultivo);
       }
+      continue;
     }
 
-    // cambio de etapa
-    if (c.progreso >= 1 && c.etapa !== 'COSECHA') {
-      c.etapa = 'COSECHA';
+    const config = CROP_CONFIG[cultivo.tipo];
+    if (!config) continue;
+
+    const recAguaId = p.recursos.find(rid => State.repos.recursos.get(rid)?.tipo === 'AGUA');
+    if (!recAguaId) {
+      cultivo.saludActual = Math.max(0, cultivo.saludActual - HEALTH_DECAY_RATE);
+      if (cultivo.saludActual <= 0 && cultivo.etapa !== 'MUERTO') {
+        cultivo.etapa = 'MUERTO';
+        notifyCropStageChange(cultivo);
+      }
+      continue;
+    }
+
+    const recursoAgua = State.repos.recursos.get(recAguaId);
+    const consumoAgua = config.consumoAgua ?? cultivo.consumoAgua ?? 1;
+    recursoAgua.nivel = Math.max(0, recursoAgua.nivel - (BASE_GROWTH_RATE * consumoAgua));
+
+    if (recursoAgua.nivel > WATER_THRESHOLD_GROW) {
+      let velocidadCrecimiento = BASE_GROWTH_RATE * (30 / (config.diasCrecimiento || 30));
+
+      if (p.saludSuelo > 0.8) velocidadCrecimiento *= 1.2;
+      if (p.saludSuelo < 0.4) velocidadCrecimiento *= 0.7;
+
+      velocidadCrecimiento *= Math.max(cultivo.saludActual, 0);
+
+      cultivo.progreso = Math.min(1, cultivo.progreso + velocidadCrecimiento);
+
+      if (cultivo.saludActual < 1 && recursoAgua.nivel > 0.5) {
+        cultivo.saludActual = Math.min(1, cultivo.saludActual + HEALTH_RECOVERY_RATE);
+      }
+
+      const etapaAnterior = cultivo.etapa;
+      updateCropStage(cultivo, config);
+      if (cultivo.etapa !== etapaAnterior) {
+        notifyCropStageChange(cultivo);
+      }
+    } else if (recursoAgua.nivel < WATER_THRESHOLD_DECAY) {
+      cultivo.saludActual = Math.max(0, cultivo.saludActual - HEALTH_DECAY_RATE);
+      if (cultivo.saludActual <= 0 && cultivo.etapa !== 'MUERTO') {
+        cultivo.etapa = 'MUERTO';
+        notifyCropStageChange(cultivo);
+      }
     }
   }
 }
+
+function updateCropStage(cultivo, config) {
+  if (!config?.etapas?.length) return;
+  const etapas = config.etapas;
+  const progreso = cultivo.progreso ?? 0;
+  const index = Math.min(Math.floor(progreso * etapas.length), etapas.length - 1);
+  const etapa = etapas[index];
+  if (cultivo.etapa !== etapa) {
+    cultivo.etapa = etapa;
+  }
+}
+
+export function isCultivoListo(cultivoId) {
+  const cultivo = repoGet('cultivos', cultivoId);
+  if (!cultivo) return false;
+  return cultivo.etapa === 'COSECHA' && (cultivo.progreso ?? 0) >= 0.8;
+}
+
+export function getCultivoInfo(cultivoId) {
+  const cultivo = repoGet('cultivos', cultivoId);
+  if (!cultivo) return null;
+
+  const config = CROP_CONFIG[cultivo.tipo];
+  if (!config) return null;
+
+  return {
+    tipo: cultivo.tipo,
+    nombre: config.nombre,
+    etapa: cultivo.etapa,
+    progreso: cultivo.progreso,
+    salud: cultivo.saludActual,
+    listo: isCultivoListo(cultivoId),
+    precioVenta: config.precioVenta
+  };
+}
+


### PR DESCRIPTION
## Summary
- add crop configurations and stage-based growth logic that tracks health, water consumption, and readiness for harvest
- update the game scene to render crop-stage emojis, manage planting/harvest flows with the new crop data, and keep parcel-to-crop mappings consistent
- extend the factory crop defaults to include health, resistance, and new stage settings so planted crops align with the simulation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3505ea17c83249e2c2c960679433a