### PR TITLE
Show parcel tooltips for low water alerts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,48 @@
+# Cultivarium
+
+Cultivarium is an agricultural simulation prototype created for the NASA Space Apps Challenge 2025. The project brings the complexity of climate-smart farming to students and enthusiasts through an interactive dashboard where key metrics are visualized and strategic decisions are made for each plot.
+
+## Simulator goals
+- Represent agricultural campaigns that progress through levels grouping biomes and world regions inspired by NASA satellite observations.
+- Translate remote-sensing indicators into intuitive bars for plant health (NDVI), heat stress, soil moisture (SMAP), precipitation (GPM), and player resources.
+- Support crop cycle management with actions such as plowing, watering, planting, harvesting, selling, and scanning, reflecting their impact on energy, finances, and pest risk.
+- Educate about agricultural decision-making by showing simulated dates, campaign days, alerts, and real-time diagnostics for the selected plot.
+
+## Simulated experience
+- **Dynamic plots:** every parcel tracks soil health, crop progress, water level, and pest status, including percentage risk and intensity.
+- **Environmental indicators:** heat, humidity, rainfall, and energy bars help prioritize actions during extreme events.
+- **Economic management:** the player's wallet and energy costs determine which actions remain available each turn.
+- **Agricultural timeline:** the HUD displays the campaign day, simulated calendar date, and the active level (e.g., “Pacific Coast”, “Breadbasket of India”).
+- **Alerts and inspection:** the left panel shows detailed diagnostics for the selected plot plus system alerts that demand quick responses.
+
+## Technology stack
+- [Phaser 3](https://phaser.io/): 2D engine driving the scene logic (`BootScene`, `PreloadScene`, `MenuScene`, `GameScene`, `UIScene`).
+- [Vite](https://vitejs.dev/): lightning-fast bundler and development server.
+- Modern JavaScript (ES Modules) organized across `src/core`, `src/scenes`, `src/systems`, and `src/utils`.
+
+## Project structure
+```
+├── public/                # Static assets
+├── src/
+│   ├── core/              # Global state, entity factory, and simulated time control
+│   ├── data/              # Levels, regions, and localized text (ES/EN)
+│   ├── map/               # Isometric map and parcel construction
+│   ├── scenes/            # Phaser scenes governing flow and UI
+│   ├── systems/           # Simulation systems (climate, crops, economy)
+│   └── utils/             # Shared helpers (i18n, utilities)
+├── README.en.md           # English documentation (this file)
+├── README.es.md           # Spanish documentation
+├── package.json           # Dependencies (Phaser 3 + Vite)
+└── vite.config.js         # Build configuration
+```
+
+## Getting started locally
+1. Install dependencies with `npm install`.
+2. Launch the development server via `npm run dev` and open `http://localhost:5173`.
+3. Build an optimized bundle with `npm run build` and serve the `dist/` directory.
+
+## Public deployment
+The latest prototype build is live at **https://cultivariumproject.earth/**
+
+## Team and credits
+Cultivarium blends design, data science, and engineering to make sustainable agriculture approachable. The prototype integrates metrics inspired by NASA Harvest, SMAP, GPM, and NDVI observations to craft accessible learning scenarios.

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,48 @@
+# Cultivarium
+
+Cultivarium es un prototipo de simulador agrícola desarrollado para el NASA Space Apps Challenge 2025. El proyecto busca acercar a estudiantes y entusiastas a la complejidad de la agricultura climáticamente inteligente mediante un tablero interactivo donde se visualizan métricas clave y se toman decisiones estratégicas sobre parcelas de cultivo.
+
+## Objetivos del simulador
+- Representar la progresión de campañas agrícolas por niveles que agrupan biomas y regiones del mundo basados en datos satelitales de NASA y misiones asociadas.
+- Traducir indicadores de teledetección en barras intuitivas para salud vegetal (NDVI), estrés térmico, humedad del suelo (SMAP), precipitación (GPM) y recursos del jugador.
+- Permitir la gestión de ciclos de cultivo con acciones como arar, regar, sembrar, cosechar, vender y escanear, reflejando impactos en energía, finanzas y riesgo de plagas.
+- Educar sobre la toma de decisiones agrícola mostrando fechas simuladas, días de campaña, alertas y diagnósticos de parcelas en tiempo real.
+
+## Experiencia simulada
+- **Parcelas dinámicas:** cada parcela registra salud de suelo, progreso del cultivo, nivel de agua y estado de plagas, incluyendo riesgo (%) e intensidad.
+- **Indicadores ambientales:** barras de calor, humedad, lluvia y energía ayudan a priorizar decisiones durante eventos extremos.
+- **Gestión económica:** la cartera del jugador y los costos de energía influyen en qué acciones están disponibles en cada turno.
+- **Cronograma agrícola:** el HUD indica el día de la campaña, la fecha simulada y el nivel activo (ej. “Costa del Pacífico”, “Graneros de India”).
+- **Alertas e inspección:** el panel izquierdo muestra diagnósticos detallados de la parcela seleccionada y alertas del sistema para actuar con rapidez.
+
+## Tecnologías utilizadas
+- [Phaser 3](https://phaser.io/): motor 2D para la lógica de escenas (`BootScene`, `PreloadScene`, `MenuScene`, `GameScene`, `UIScene`).
+- [Vite](https://vitejs.dev/): entorno de bundling y servidor de desarrollo ultrarrápido.
+- JavaScript moderno (ES Modules) organizado en `src/core`, `src/scenes`, `src/systems` y `src/utils`.
+
+## Estructura del proyecto
+```
+├── public/                # Activos estáticos
+├── src/
+│   ├── core/              # Estado global, fábrica de entidades y control del tiempo simulado
+│   ├── data/              # Niveles, regiones y textos traducidos (ES/EN)
+│   ├── map/               # Construcción del mapa isométrico y parcelas
+│   ├── scenes/            # Escenas de Phaser para flujo de juego y UI
+│   ├── systems/           # Sistemas de simulación (clima, cultivo, economía)
+│   └── utils/             # Utilidades comunes (i18n, helpers)
+├── README.en.md           # Documentación en inglés
+├── README.es.md           # Documentación en español (este archivo)
+├── package.json           # Dependencias (Phaser 3 + Vite)
+└── vite.config.js         # Configuración de build
+```
+
+## Puesta en marcha local
+1. Instala dependencias con `npm install`.
+2. Inicia el entorno de desarrollo con `npm run dev` y abre el navegador en `http://localhost:5173`.
+3. Para generar una build optimizada ejecuta `npm run build` y sirve la carpeta `dist/`.
+
+## Despliegue público
+La versión actual del prototipo está disponible en: **https://cultivariumproject.earth/**
+
+## Equipo y créditos
+Cultivarium combina el trabajo de diseño, ciencia de datos y desarrollo para acercar la agricultura sostenible a nuevos públicos. El proyecto integra métricas inspiradas en los programas NASA Harvest, SMAP, GPM y observaciones NDVI para construir escenarios de aprendizaje accesibles.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# Project-Cultivarium
-A game made for the Nasa Space Challenge 2025
+# Cultivarium
+
+Cultivarium is an agricultural simulation prototype built with Phaser 3 and Vite for the NASA Space Apps Challenge 2025. It provides a dashboard-style experience where players manage plots, react to environmental indicators, and explore data-informed farming decisions.
+
+- 📄 [Documentación en español](README.es.md)
+- 📄 [English documentation](README.en.md)
+
+Visit the live prototype at **https://cultivariumproject.earth/**.

--- a/src/core/factory.js
+++ b/src/core/factory.js
@@ -143,6 +143,7 @@ export const Factory = {
       mensaje: overrides.mensaje || 'Alerta creada',
       parcelaId: overrides.parcelaId || null,
       visible: true,
+      codigo: overrides.codigo || null,
       ...overrides
     };
     repoSet('alertas', e);

--- a/src/data/menuTranslations.json
+++ b/src/data/menuTranslations.json
@@ -24,11 +24,11 @@
         },
         "ui": {
             "defaultPlayerName": "Agente",
-            "defaultLocation": "Pampa H\u00fameda, AR",
+            "levelDisplay": "Nivel: {{level}}",
             "dayLabel": "D\u00eda",
             "dayDisplay": "{{label}}: {{day}}",
             "clockFallbackLevel": "Nivel",
-            "clockDisplay": "{{level}} \u2014 {{dayLabel}} {{day}}/{{totalDays}} \u2014 {{date}}",
+            "clockDisplay": "{{dayLabel}} {{day}}/{{totalDays}} \u2014 {{date}}",
             "fpsLabel": "FPS: {{value}}",
             "moneyLabel": "\u20b2 {{value}}",
             "inspectTitle": "\ud83d\udd2c Inspecci\u00f3n de Parcela",
@@ -45,6 +45,9 @@
             },
             "alertsTitle": "\u26a0\ufe0f Alertas del Sistema",
             "alertsEmpty": "No hay alertas activas.",
+            "alerts": {
+                "lowWater": "Agua baja en parcela {{parcel}}"
+            },
             "actionPanelTitle": "Decisiones",
             "barLabels": {
                 "health": "SALUD (NDVI)",
@@ -138,11 +141,11 @@
         },
         "ui": {
             "defaultPlayerName": "Agent",
-            "defaultLocation": "Humid Pampas, AR",
+            "levelDisplay": "Level: {{level}}",
             "dayLabel": "Day",
             "dayDisplay": "{{label}}: {{day}}",
             "clockFallbackLevel": "Level",
-            "clockDisplay": "{{level}} \u2014 {{dayLabel}} {{day}}/{{totalDays}} \u2014 {{date}}",
+            "clockDisplay": "{{dayLabel}} {{day}}/{{totalDays}} \u2014 {{date}}",
             "fpsLabel": "FPS: {{value}}",
             "moneyLabel": "\u20b2 {{value}}",
             "inspectTitle": "\ud83d\udd2c Plot Inspection",
@@ -159,6 +162,9 @@
             },
             "alertsTitle": "\u26a0\ufe0f System Alerts",
             "alertsEmpty": "No active alerts.",
+            "alerts": {
+                "lowWater": "Low water on plot {{parcel}}"
+            },
             "actionPanelTitle": "Decisions",
             "barLabels": {
                 "health": "HEALTH (NDVI)",

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -228,6 +228,7 @@ export default class GameScene extends Phaser.Scene {
     this.timeOfDay = 0.5;   // 0..1 (se sincroniza con la simulación al iniciar)
     this.parcelaIdByCultivoId = new Map();
     this.cultivoSprites = new Map();
+    this.alertMarkers = new Map();
   }
 
   create() {
@@ -292,6 +293,7 @@ export default class GameScene extends Phaser.Scene {
     this.spriteByParcela = new Map();
     this.parcelaIdByCultivoId = new Map();
     this.cultivoSprites = new Map();
+    this.alertMarkers = new Map();
     this.selectedParcelaId = null;
 
     // helper
@@ -560,6 +562,8 @@ export default class GameScene extends Phaser.Scene {
     this.game.events.on('action:perform', this._onUIAction);
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.game.events.off('action:perform', this._onUIAction);
+      this.alertMarkers.forEach(marker => marker.destroy());
+      this.alertMarkers.clear();
     });
 
     if (!this.scene.isActive('UI')) this.scene.launch('UI');
@@ -648,6 +652,119 @@ export default class GameScene extends Phaser.Scene {
     if (existing) {
       existing.destroy();
       this.cultivoSprites.delete(parcelaId);
+    }
+  }
+
+  createAlertMarker(alert, pos) {
+    if (!pos) return null;
+    const container = this.add.container(pos.x, pos.y - 64);
+    container.setDepth(pos.y + 1200);
+
+    const bubble = this.add.graphics();
+    const text = this.add.text(0, 0, '', {
+      fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+      fontSize: '12px',
+      color: '#f8fafc',
+      align: 'center'
+    }).setOrigin(0.5, 1);
+
+    const padX = 14;
+    const padY = 8;
+    const pointerHeight = 14;
+    const maxWidth = 220;
+    text.setWordWrapWidth(maxWidth - padX * 2, true);
+
+    const redraw = (message, targetPos) => {
+      if (targetPos) {
+        container.setPosition(targetPos.x, targetPos.y - 64);
+        container.setDepth(targetPos.y + 1200);
+      }
+      text.setText(message || '');
+      const wrapWidth = maxWidth - padX * 2;
+      text.setWordWrapWidth(wrapWidth, true);
+      const contentWidth = Math.min(wrapWidth, text.width);
+      const width = Math.max(96, contentWidth + padX * 2);
+      const height = text.height + padY * 2;
+      const pointerTop = -pointerHeight;
+      const bubbleTop = pointerTop - height;
+      const pointerHalf = Math.min(16, width / 4);
+
+      bubble.clear();
+      bubble.fillStyle(0x111827, 0.92);
+      bubble.fillRoundedRect(-width / 2, bubbleTop, width, height, 10);
+      bubble.fillTriangle(-pointerHalf, pointerTop, pointerHalf, pointerTop, 0, 0);
+      bubble.lineStyle(1, 0xfacc15, 0.9);
+      bubble.strokeRoundedRect(-width / 2, bubbleTop, width, height, 10);
+      bubble.strokeTriangle(-pointerHalf, pointerTop, pointerHalf, pointerTop, 0, 0);
+      text.y = pointerTop - padY;
+    };
+
+    container.add([bubble, text]);
+    redraw(alert.mensaje, pos);
+
+    const bob = this.tweens.add({
+      targets: container,
+      y: container.y - 6,
+      duration: 1600,
+      ease: 'Sine.easeInOut',
+      yoyo: true,
+      repeat: -1
+    });
+
+    return {
+      container,
+      text,
+      bubble,
+      update: (message, nextPos) => redraw(message, nextPos),
+      destroy: () => {
+        if (bob) bob.stop();
+        container.destroy();
+      }
+    };
+  }
+
+  syncAlertMarkers() {
+    if (!this.alertMarkers) this.alertMarkers = new Map();
+    const activeAlerts = repoAll('alertas');
+    const keep = new Set();
+
+    for (const alert of activeAlerts) {
+      const isVisible = alert && alert.visible !== false;
+      if (!isVisible) continue;
+      const blockId = alert.parcelaId ? this.blockIdByParcelaId.get(alert.parcelaId) : null;
+      const pos = blockId ? this.blockPositions.get(blockId) : null;
+      const marker = this.alertMarkers.get(alert.id);
+      if (!pos) {
+        if (marker) {
+          marker.destroy();
+          this.alertMarkers.delete(alert.id);
+        }
+        continue;
+      }
+
+      keep.add(alert.id);
+
+      if (!marker) {
+        const created = this.createAlertMarker(alert, pos);
+        if (created) {
+          this.alertMarkers.set(alert.id, { ...created, message: alert.mensaje });
+        }
+        continue;
+      }
+
+      if (marker.message !== alert.mensaje) {
+        marker.message = alert.mensaje;
+        marker.update(alert.mensaje, pos);
+      } else {
+        marker.update(alert.mensaje, pos);
+      }
+    }
+
+    for (const [id, marker] of this.alertMarkers.entries()) {
+      if (!keep.has(id)) {
+        marker.destroy();
+        this.alertMarkers.delete(id);
+      }
     }
   }
 
@@ -946,6 +1063,7 @@ export default class GameScene extends Phaser.Scene {
         .catch(err => console.error('climate:tick', err));
     }
     tickCrops(); tickPlagues(); tickAlerts();
+    this.syncAlertMarkers();
 
     // 8) Secado periódico
     if ((State.clock % 15) === 0) {

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -17,6 +17,7 @@ export default class UIScene extends Phaser.Scene {
     this.alertsText = null;
     this.dayText = null;
     this.playerNameText = null;
+    this.levelText = null;
     this.heatAlertTween = null; // Control del Tween
     this._dom = null;        // refs DOM cacheadas
     this._domLast = null;    // último snapshot para evitar trabajo repetido
@@ -117,8 +118,33 @@ export default class UIScene extends Phaser.Scene {
       side === 'left' ? '◀' : '▶',
       { fontSize: '32px', color: colors.textPrimary, fontStyle: 'bold' }
     ).setOrigin(0.5).setInteractive({ useHandCursor: true });
+    toggleButton.setDepth(1);
 
-    container.add([panelBg, toggleButton]);
+    const maskShape = this.add.graphics();
+    maskShape.fillStyle(0xffffff, 1);
+    maskShape.fillRect(0, 0, width, height);
+    maskShape.setAlpha(0.0001);
+
+    const content = this.add.container(0, 0);
+
+    container.add([panelBg, maskShape, content, toggleButton]);
+
+    container.setSize(width, height);
+    container.setInteractive(new Phaser.Geom.Rectangle(0, 0, width, height), Phaser.Geom.Rectangle.Contains);
+
+    const geometryMask = maskShape.createGeometryMask();
+    content.setMask(geometryMask);
+
+    const panelState = { maxScroll: 0 };
+
+    container.on('wheel', (pointer, deltaX, deltaY, deltaZ, event) => {
+      if (panelState.maxScroll <= 0) return;
+      const nextY = Phaser.Math.Clamp(content.y - deltaY, -panelState.maxScroll, 0);
+      if (nextY !== content.y) {
+        content.y = nextY;
+      }
+      if (event?.preventDefault) event.preventDefault();
+    });
 
     let isCollapsed = false;
     toggleButton.on('pointerdown', () => {
@@ -132,18 +158,27 @@ export default class UIScene extends Phaser.Scene {
       toggleButton.setText(isCollapsed ? (side === 'left' ? '▶' : '◀') : (side === 'left' ? '◀' : '▶'));
     });
 
-    return { container, width, height, side };
+    return {
+      container,
+      content,
+      width,
+      height,
+      side,
+      setMaxScroll: (value) => {
+        panelState.maxScroll = Math.max(0, value);
+      }
+    };
   }
 
   // ---------- Status/Data + Inspección + Alertas ----------
   populateStatusPanel(panel, colors) {
-    const container = panel.container;
+    const container = panel.content;
     const W = panel.width;
     let y = 20;
 
     // Nombre / Ubicación
     this.playerNameText = this.add.text(W / 2, y, '', { fontSize: '24px', color: colors.textPrimary, fontStyle: 'bold' }).setOrigin(0.5, 0);
-    this.locationText = this.add.text(W / 2, y += 30, '', { fontSize: '16px', color: colors.textSecondary }).setOrigin(0.5, 0);
+    this.levelText = this.add.text(W / 2, y += 30, '', { fontSize: '16px', color: colors.textSecondary }).setOrigin(0.5, 0);
 
     // Día destacado (Aplica colores Data Accent)
     this.dayText = this.add.text(W / 2, y += 30, '', {
@@ -194,7 +229,7 @@ export default class UIScene extends Phaser.Scene {
     this.inspectTitle = this.add.text(24, y, '', { fontSize: '18px', color: colors.dataAccent, fontStyle: 'bold' });
     this.inspectText = this.add.text(24, y + 24, '', { fontSize: '12px', color: colors.textSecondary, wordWrap: { width: W - 48 } });
 
-    container.add([this.playerNameText, this.locationText, this.dayText, this.inspectTitle, this.inspectText]);
+    container.add([this.playerNameText, this.levelText, this.dayText, this.inspectTitle, this.inspectText]);
     container.bringToTop(this.dayText);
 
     const sep2 = this.add.graphics().fillStyle(colors.panelBorder, 0.5).fillRect(16, y += 110, W - 32, 2);
@@ -204,11 +239,15 @@ export default class UIScene extends Phaser.Scene {
     this.alertsTitle = this.add.text(24, y, '', { fontSize: '18px', color: colors.bar.heat, fontStyle: 'bold' });
     this.alertsText = this.add.text(24, y + 24, '', { fontSize: '12px', color: colors.textPrimary, wordWrap: { width: W - 48 } });
     container.add([this.alertsTitle, this.alertsText]);
+    this.alertsTitle.setVisible(false);
+    this.alertsText.setVisible(false);
+
+    this.updatePanelScroll(panel);
   }
 
 // ---------- Panel de Acciones ----------
 populateActionPanel(panel, colors) {
-  const container = panel.container;
+  const container = panel.content;
   const W = panel.width;
   let y = 20;
 
@@ -265,11 +304,6 @@ populateActionPanel(panel, colors) {
           this.game.events.emit('action:perform', { actionType: cfg.eventType });
         }
 
-        const feedbackText = t(`ui.actions.${cfg.key}.feedback`);
-        if (feedbackText) {
-          this.showActionFeedback(feedbackText, cfg.feedbackColor);
-        }
-
         this.tweens.add({ targets: [btn.bg, btn.text], scale: 0.96, duration: 80, yoyo: true, ease: 'Quad.easeInOut' });
 
         const prevColor = btn.bg.fillColor;
@@ -301,7 +335,29 @@ populateActionPanel(panel, colors) {
       y += 12;
     }
   });
+  this.updatePanelScroll(panel);
 }
+
+  updatePanelScroll(panel) {
+    if (!panel?.content || typeof panel.setMaxScroll !== 'function') return;
+    const bounds = panel.content.getBounds();
+    if (!bounds) {
+      panel.setMaxScroll(0);
+      panel.content.y = 0;
+      return;
+    }
+
+    const containerWorldY = panel.container?.y ?? 0;
+    const top = bounds.y - containerWorldY;
+    const bottom = (bounds.bottom ?? (bounds.y + bounds.height)) - containerWorldY;
+    const contentHeight = Math.max(bottom - Math.min(0, top), 0);
+    const maxScroll = Math.max(0, contentHeight - panel.height);
+
+    panel.setMaxScroll(maxScroll);
+
+    if (panel.content.y < -maxScroll) panel.content.y = -maxScroll;
+    if (panel.content.y > 0) panel.content.y = 0;
+  }
     
   // ---------- Feedback flotante ----------
   showActionFeedback(msg, colorHex) {
@@ -385,7 +441,7 @@ populateActionPanel(panel, colors) {
     bg.lineStyle(2, colors.panelBorder).strokeRoundedRect(0, 0, width, height, 14);
     bg.setPosition(pad, y);
 
-    const t = this.add.text(panelWidth / 2, y + height / 2, text, {
+    const labelText = this.add.text(panelWidth / 2, y + height / 2, text, {
       fontSize: '20px', color: colors.textPrimary, fontStyle: 'bold'
     }).setOrigin(0.5);
 
@@ -414,11 +470,10 @@ populateActionPanel(panel, colors) {
     // Click
     bg.on('pointerdown', () => {
       if (bg.input?.enabled) {
-        this.tweens.add({ targets: [bg, t], scale: 0.96, duration: 80, yoyo: true, ease: 'Quad.easeInOut' });
+        this.tweens.add({ targets: [bg, labelText], scale: 0.96, duration: 80, yoyo: true, ease: 'Quad.easeInOut' });
         onClick();
       } else {
         this.tweens.add({ targets: bg, x: bg.x + 5, duration: 50, yoyo: true, repeat: 1, ease: 'Sine.easeInOut' });
-        this.showActionFeedback(t('ui.actions.blocked'), this.colors.bar.heat);
       }
     });
 
@@ -426,7 +481,7 @@ populateActionPanel(panel, colors) {
     bg.on('pointerout',  () => { if (bg.input?.enabled) bg.fillColor = colors.actionButton; });
 
     // Devuelve helpers
-    return { elements: [bg, t], bg, text: t, enable, disable, hitArea };
+    return { elements: [bg, labelText], bg, text: labelText, enable, disable, hitArea };
   }
 
   formatDateForLang(date, lang = getLanguage()) {
@@ -454,9 +509,8 @@ populateActionPanel(panel, colors) {
       this.playerNameText.setText(profileName || t('ui.defaultPlayerName'));
     }
 
-    if (this.locationText) {
-      const profileLocation = window.__CV_START__?.profile?.location;
-      this.locationText.setText(profileLocation || t('ui.defaultLocation'));
+    if (this.levelText) {
+      this.levelText.setText(t('ui.levelDisplay', { level: levelName }));
     }
 
     if (this.dayText) {
@@ -465,7 +519,6 @@ populateActionPanel(panel, colors) {
 
     if (this.clockText) {
       this.clockText.setText(t('ui.clockDisplay', {
-        level: levelName,
         dayLabel,
         day: dayN,
         totalDays,
@@ -519,12 +572,16 @@ populateActionPanel(panel, colors) {
     } else if (this.inspectText) {
       this.inspectText.setText(t('ui.inspectPlaceholder'));
     }
+
+    this.updatePanelScroll(this.statusPanel);
+    this.updatePanelScroll(this.actionPanel);
   }
 
   updateInspectPanel(data) {
     if (!this.inspectText) return;
     if (!data) {
       this.inspectText.setText(t('ui.inspectPlaceholder'));
+      this.updatePanelScroll(this.statusPanel);
       return;
     }
 
@@ -562,6 +619,7 @@ populateActionPanel(panel, colors) {
     ];
 
     this.inspectText.setText(lines.join('\n'));
+    this.updatePanelScroll(this.statusPanel);
   }
 
 
@@ -650,7 +708,6 @@ populateActionPanel(panel, colors) {
 
     if (this.clockText) {
       this.clockText.setText(t('ui.clockDisplay', {
-        level: levelName,
         dayLabel,
         day: dayN,
         totalDays,
@@ -669,12 +726,19 @@ populateActionPanel(panel, colors) {
 
     if (this.playerNameText) {
       const profileName = window.__CV_START__?.profile?.name;
-      this.playerNameText.setText(profileName || t('ui.defaultPlayerName'));
+      const nextName = profileName || t('ui.defaultPlayerName');
+      if (this.playerNameText.text !== nextName) {
+        this.playerNameText.setText(nextName);
+        this.updatePanelScroll(this.statusPanel);
+      }
     }
 
-    if (this.locationText) {
-      const profileLocation = window.__CV_START__?.profile?.location;
-      this.locationText.setText(profileLocation || t('ui.defaultLocation'));
+    if (this.levelText) {
+      const nextLevel = t('ui.levelDisplay', { level: levelName });
+      if (this.levelText.text !== nextLevel) {
+        this.levelText.setText(nextLevel);
+        this.updatePanelScroll(this.statusPanel);
+      }
     }
 
     const CRITICAL_HEAT_THRESHOLD = 0.70;
@@ -719,10 +783,12 @@ populateActionPanel(panel, colors) {
       }
     });
 
-    const alerts = repoAll('alertas').filter(a => a.visible !== false).slice(-5);
-    const alertsText = alerts.length ? alerts.map(a => `• ${a.mensaje}`).join('\n') : t('ui.alertsEmpty');
-    if (this.alertsText) {
+    if (this.alertsText?.visible) {
+      const alerts = repoAll('alertas').filter(a => a.visible !== false).slice(-5);
+      const alertsText = alerts.length ? alerts.map(a => `• ${a.mensaje}`).join('\n') : t('ui.alertsEmpty');
       this.alertsText.setText(alertsText);
+    } else if (this.alertsText) {
+      this.alertsText.setText('');
     }
   }
 }

--- a/src/systems/alertSystem.js
+++ b/src/systems/alertSystem.js
@@ -6,19 +6,33 @@
 import { State, repoAll } from '../core/state.js';
 import { Factory } from '../core/factory.js';
 import { ALERTAS_TIPO } from '../data/enums.js';
+import { translate as t } from '../utils/i18n.js';
 
 export function tickAlerts() {
   const parcelas = repoAll('parcelas');
+  const alertsRepo = State.repos.alertas;
   for (const p of parcelas) {
     const agua = p.recursos
       .map(id => State.repos.recursos.get(id))
       .find(r => r?.tipo === 'AGUA');
+    const existingLowWaterAlert = Array.from(alertsRepo.values())
+      .find(a => a.parcelaId === p.id && a.codigo === 'LOW_WATER');
+
     if (agua && agua.nivel < 0.15) {
-      Factory.createAlerta({
-        tipo: ALERTAS_TIPO.RIESGO,
-        mensaje: `Agua baja en parcela ${p.id}`,
-        parcelaId: p.id
-      });
+      const message = t('ui.alerts.lowWater', { parcel: p.id });
+      if (existingLowWaterAlert) {
+        existingLowWaterAlert.visible = true;
+        existingLowWaterAlert.mensaje = message;
+      } else {
+        Factory.createAlerta({
+          tipo: ALERTAS_TIPO.RIESGO,
+          mensaje: message,
+          parcelaId: p.id,
+          codigo: 'LOW_WATER'
+        });
+      }
+    } else if (existingLowWaterAlert) {
+      existingLowWaterAlert.visible = false;
     }
   }
 }


### PR DESCRIPTION
## Summary
- de-duplicate low-water alerts and translate their message through the i18n table
- render those alerts as animated parcel tooltips while hiding the unused list in the status panel
- clear alert markers with the scene lifecycle so only GameScene toasts remain active feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3542bce788324a6be64305733d4e8